### PR TITLE
Get statistics from last campaign

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ Then add 'hubot-mailchimp' to your `external_scripts.json` file and run `npm ins
 ## Config
 
     MAILCHIMP_API_KEY
-	MAILCHIMP_LIST_ID
+	  MAILCHIMP_LIST_ID
 
 ## Commands
 
     hubot subscribe <email> - Add email to list
     hubot unsubscribe <email> - Remove email from list
+    hubot mailchimp - Get statistics from latest mailing

--- a/scripts/mailchimp-subscribe.coffee
+++ b/scripts/mailchimp-subscribe.coffee
@@ -14,7 +14,7 @@
 #   hubot mailchimp - Get statistics from latest mailing
 #
 # Author:
-#   max, lmarburger, m-baumgartner, sporkmonger
+#   max, lmarburger, m-baumgartner, sporkmonger, stephenyeargin
 
 MailChimpAPI = require('mailchimp').MailChimpAPI
 
@@ -98,5 +98,4 @@ latestCampaign = (message) ->
         if error
           message.send "Uh oh, something went wrong: #{error.message}"
         else
-          stats = data['data']
-          message.send "Last campaign \"#{campaign_name}\" was sent to #{stats['emails_sent']} subscribers (#{stats['unique_opens']} opened, #{stats['unique_clicks']} clicked, #{stats['unsubscribes']} unsubscribed)"
+          message.send "Last campaign \"#{campaign_name}\" was sent to #{data['emails_sent']} subscribers (#{data['unique_opens']} opened, #{data['unique_clicks']} clicked, #{data['unsubscribes']} unsubscribed)"


### PR DESCRIPTION
Prior to this PR, the `hubot-mailchimp` package could add and remove users from a given mailing list. This PR adds an additional command, simply called `mailchimp` that will return statistics for the last campaign that has been sent.

Fixes #3.

Demo:

```
User> hubot mailchimp
Hubot> Last campaign "Super Spring Sportswear Sale!" was sent to 255 subscribers (154 opened, 95 clicked, 10 unsubscribed)
```
